### PR TITLE
Add default keyword file

### DIFF
--- a/GOs Character Gen.pyw
+++ b/GOs Character Gen.pyw
@@ -47,6 +47,7 @@ encounters_file = os.path.join(presets_dir, "encounters.json")
 # the user's install directory they will be created from the bundled defaults.
 default_armor_path = os.path.join(os.path.dirname(__file__), "default_armors.json")
 default_weapon_path = os.path.join(os.path.dirname(__file__), "default_weapons.json")
+default_keywords_path = os.path.join(os.path.dirname(__file__), "default_keywords.json")
 
 armors_data = []
 weapons_data = []
@@ -549,24 +550,31 @@ def save_presets_to_file():
 # ==========================
 def load_keywords():
     global keywords
+    data = {}
     if os.path.exists(keywords_file):
         try:
             with open(keywords_file, "r") as f:
                 data = json.load(f)
-            keywords = {}
-            for k, v in data.items():
-                if isinstance(v, dict):
-                    keywords[k] = {
-                        "desc": v.get("desc", ""),
-                        "variable": bool(v.get("variable", False)),
-                    }
-                else:
-                    keywords[k] = {"desc": v, "variable": False}
         except Exception as e:
             print("Error loading keywords:", e)
-            keywords = {}
-    else:
-        keywords = {}
+    elif os.path.exists(default_keywords_path):
+        try:
+            with open(default_keywords_path, "r") as f:
+                data = json.load(f)
+            with open(keywords_file, "w") as out:
+                json.dump(data, out, indent=2)
+        except Exception as e:
+            print("Error loading default keywords:", e)
+            data = {}
+    keywords = {}
+    for k, v in data.items():
+        if isinstance(v, dict):
+            keywords[k] = {
+                "desc": v.get("desc", ""),
+                "variable": bool(v.get("variable", False)),
+            }
+        else:
+            keywords[k] = {"desc": v, "variable": False}
     detect_list_keywords()
     update_keywords_listbox()
     update_keyword_highlights()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # GO-Charactergen
 A program for creating quick, simple characters in mutants and masterminds and tracking them.
 
+Default keyword definitions are stored in `default_keywords.json` and copied to the
+user directory on first run.
+
 Keywords now support variable levels.  When a keyword is marked as variable it
 will be displayed in the format `Keyword(X)` in the keyword list.  Use the `{#}`
 placeholder inside a keyword's description to insert the numeric level when the

--- a/default_keywords.json
+++ b/default_keywords.json
@@ -1,0 +1,122 @@
+{
+  "Medieval": {
+    "desc": "",
+    "variable": false
+  },
+  "Light": {
+    "desc": "",
+    "variable": false
+  },
+  "Medium": {
+    "desc": "",
+    "variable": false
+  },
+  "Heavy": {
+    "desc": "",
+    "variable": false
+  },
+  "Modern": {
+    "desc": "",
+    "variable": false
+  },
+  "Ablative": {
+    "desc": "",
+    "variable": false
+  },
+  "Sealed": {
+    "desc": "",
+    "variable": false
+  },
+  "Postmodern": {
+    "desc": "",
+    "variable": false
+  },
+  "Power": {
+    "desc": "",
+    "variable": false
+  },
+  "Nanite": {
+    "desc": "",
+    "variable": false
+  },
+  "Melee": {
+    "desc": "",
+    "variable": false
+  },
+  "Thrown": {
+    "desc": "",
+    "variable": false
+  },
+  "Finesse": {
+    "desc": "",
+    "variable": false
+  },
+  "Stealth": {
+    "desc": "",
+    "variable": false
+  },
+  "Riposte": {
+    "desc": "",
+    "variable": false
+  },
+  "Improved Crit": {
+    "desc": "",
+    "variable": true
+  },
+  "Crushing": {
+    "desc": "",
+    "variable": true
+  },
+  "Cleaving": {
+    "desc": "",
+    "variable": false
+  },
+  "2-Hand": {
+    "desc": "",
+    "variable": false
+  },
+  "Reach": {
+    "desc": "",
+    "variable": true
+  },
+  "Ranged": {
+    "desc": "",
+    "variable": false
+  },
+  "Ammunition": {
+    "desc": "",
+    "variable": false
+  },
+  "Reload": {
+    "desc": "",
+    "variable": false
+  },
+  "Defensive": {
+    "desc": "",
+    "variable": false
+  },
+  "Brutal": {
+    "desc": "",
+    "variable": false
+  },
+  "Unwieldy": {
+    "desc": "",
+    "variable": false
+  },
+  "Entangling": {
+    "desc": "",
+    "variable": false
+  },
+  "Hooking": {
+    "desc": "",
+    "variable": false
+  },
+  "Piercing": {
+    "desc": "",
+    "variable": true
+  },
+  "Multiattack": {
+    "desc": "",
+    "variable": true
+  }
+}


### PR DESCRIPTION
## Summary
- load and save keywords from a `default_keywords.json` file
- store example keyword definitions
- document new keyword file in README

## Testing
- `python3 -m py_compile 'GOs Character Gen.pyw'`

------
https://chatgpt.com/codex/tasks/task_e_684ee1e17b008329a311d1893f338f69