### PR TITLE
Add stat modifier placeholders and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Duplicate keyword entries from earlier versions have been removed.
 Keywords now support variable levels.  When a keyword is marked as variable it
 will be displayed in the format `Keyword(X)` in the keyword list.  Use the `{#}`
 placeholder inside a keyword's description to insert the numeric level when the
-tooltip is shown.
+tooltip is shown.  Keywords may also modify base stats by including placeholders
+like `{STR(+2)}` or `{INT(-4)}` in their descriptions.  The modifier is applied
+when any item bearing the keyword is equipped.
 
 ## Weapons
 

--- a/default_keywords.json
+++ b/default_keywords.json
@@ -36,7 +36,7 @@
     "variable": false
   },
   "Heavy": {
-    "desc": "Grants a -5 penalty to stealth, athletics, and acrobatics unless the user has STR 4 or higher.",
+    "desc": "Grants a -5 penalty to stealth, athletics, and acrobatics unless the user has STR 4 or higher. {AGL(-3)}",
     "variable": false
   },
   "Hooking": {
@@ -56,7 +56,7 @@
     "variable": false
   },
   "Medium": {
-    "desc": "Grants a -2 penalty to stealth, athletics, and acrobatics unless the user has STR 2 or higher.",
+    "desc": "Grants a -2 penalty to stealth, athletics, and acrobatics unless the user has STR 2 or higher. {AGL(-1)}",
     "variable": false
   },
   "Melee": {


### PR DESCRIPTION
## Summary
- remove hardcoded agility penalties from armor
- support `{STAT(+/-#)}` placeholders in keyword descriptions that adjust base stats
- document use of the new placeholders in README, help text, and keyword dialog
- modify Heavy and Medium keywords to apply agility penalties via placeholders

## Testing
- `python -m py_compile 'GOs Character Gen.pyw'`

------
https://chatgpt.com/codex/tasks/task_e_685da0efe6a083298e82b1abc18c67b0